### PR TITLE
Miscellaneous fixes

### DIFF
--- a/toolchain/docker/base-ubuntu/Dockerfile
+++ b/toolchain/docker/base-ubuntu/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:latest as rpi-cpp-toolchain-base-ubuntu
 
 # Install some tools and compilers + clean up
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y sudo git wget \
                        gcc g++ cmake make autoconf automake \

--- a/toolchain/docker/merged/cross-build/install-scripts/googletest.sh
+++ b/toolchain/docker/merged/cross-build/install-scripts/googletest.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-version="master" # Release tag on GitHub
+version="main" # Release tag on GitHub
 
 # Download
 git clone --single-branch --depth=1 --branch $version \

--- a/toolchain/docker/merged/cross-native-toolchain/aarch64-rpi3-linux-gnu.config
+++ b/toolchain/docker/merged/cross-native-toolchain/aarch64-rpi3-linux-gnu.config
@@ -728,7 +728,7 @@ CT_ISL_V_0_22=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.22"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/toolchain/docker/merged/cross-native-toolchain/armv6-rpi-linux-gnueabihf.config
+++ b/toolchain/docker/merged/cross-native-toolchain/armv6-rpi-linux-gnueabihf.config
@@ -745,7 +745,7 @@ CT_ISL_V_0_22=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.22"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/toolchain/docker/merged/cross-native-toolchain/armv8-rpi3-linux-gnueabihf.config
+++ b/toolchain/docker/merged/cross-native-toolchain/armv8-rpi3-linux-gnueabihf.config
@@ -745,7 +745,7 @@ CT_ISL_V_0_22=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.22"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/toolchain/docker/merged/cross-toolchain/aarch64-rpi3-linux-gnu.config
+++ b/toolchain/docker/merged/cross-toolchain/aarch64-rpi3-linux-gnu.config
@@ -727,7 +727,7 @@ CT_ISL_V_0_22=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.22"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/toolchain/docker/merged/cross-toolchain/armv6-rpi-linux-gnueabihf.config
+++ b/toolchain/docker/merged/cross-toolchain/armv6-rpi-linux-gnueabihf.config
@@ -744,7 +744,7 @@ CT_ISL_V_0_22=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.22"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/toolchain/docker/merged/cross-toolchain/armv8-rpi3-linux-gnueabihf.config
+++ b/toolchain/docker/merged/cross-toolchain/armv8-rpi3-linux-gnueabihf.config
@@ -744,7 +744,7 @@ CT_ISL_V_0_22=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.22"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/toolchain/scripts/export-toolchain.sh
+++ b/toolchain/scripts/export-toolchain.sh
@@ -8,7 +8,7 @@ function export_toolchain {
     echo "Exporting toolchain ..."
     echo "Creating archives"
     container=$(docker run -d $image \
-        bash -c "tar cf x-tools.tar x-tools")
+        bash -c "tar cf x-tools.tar --hard-dereference x-tools")
     status=$(docker wait $container)
     if [ $status -ne 0 ]; then
         echo "Error creating toolchain archives"

--- a/toolchain/scripts/export.sh
+++ b/toolchain/scripts/export.sh
@@ -8,9 +8,9 @@ function export_all {
     echo "Exporting toolchain, sysroot and staging area ..."
     echo "Creating archives"
     container=$(docker run -d $image \
-        bash -c "tar cf RPi-staging.tar RPi-staging & \
-                tar cf RPi-sysroot.tar RPi-sysroot & \
-                tar cf x-tools.tar x-tools & \
+        bash -c "tar cf RPi-staging.tar --hard-dereference RPi-staging & \
+                tar cf RPi-sysroot.tar --hard-dereference RPi-sysroot & \
+                tar cf x-tools.tar --hard-dereference x-tools & \
                 wait")
     status=$(docker wait $container)
     if [ $status -ne 0 ]; then


### PR DESCRIPTION
I tried building the toolchain and the dependencies for `rpi-dev` by running the following commands on an Ubuntu 21.10 default installation:

```
./toolchain/docker/base-ubuntu/build.sh
./toolchain/docker/crosstool-ng-master/build.sh
./toolchain/toolchain.sh rpi-dev --build-toolchain --export-toolchain
./toolchain/toolchain.sh rpi-dev --export
```

I came across a few build issues, as listed below with their respective fixes.

* The build of `rpi-cpp-toolchain-base-ubuntu` gets stuck in interactive mode. Fixed by specifying non-interactive mode in the Dockerfile.
* The ISL mirror is no longer responsive. Fixed by replacing it with `https://libisl.sourceforge.io`, as they did in `crosstool-ng`.
* Tarballs fail to extract on filesystems that do not support hard linking. The fix is to create the tarballs using the `--hard-dereference` option.
* `googletest` changed its main branch from `master` to `main`. Updated.

Another issue I found, but which is not fixed in this PR, is that the toolchain build for `rpi` and `rpi-dev` fails when using the latest `crosstool-ng` master. I traced this back to [this commit](https://github.com/crosstool-ng/crosstool-ng/commit/08981c05cd9962c9557f87b4fef0c4d44684cf38) in `crosstool-ng`. I created a special branch ([https://github.com/andreasavio/RPi-Cpp-Toolchain/tree/fix/rpi1](https://github.com/andreasavio/RPi-Cpp-Toolchain/tree/fix/rpi1)) that reverts `crosstool-ng` to a previous, working commit. As the rollback fixed my problem, I did not look into this issue any further, so I did not include it in this PR, as there may be a better fix.